### PR TITLE
Matlab fixes

### DIFF
--- a/matlab/bingham_F.m
+++ b/matlab/bingham_F.m
@@ -35,7 +35,7 @@ for i=1:d
 end
 
 if d==1
-    X = F_cache.F{d}([zi0(1),zi1(1)]);
+    X = F_cache.F{d}([zi0(1),zi1(1)])';
 elseif d==2
     X = F_cache.F{d}([zi0(1),zi1(1)], [zi0(2),zi1(2)]);
 elseif d==3

--- a/matlab/bingham_pdf.m
+++ b/matlab/bingham_pdf.m
@@ -1,22 +1,20 @@
 function p = bingham_pdf(x,B)
 % p = bingham_pdf(x,B)
-
-d = length(x);
+% 
+% INPUTS:
+% x   should be N-by-D
+% B.V should be D-by-(D-1)
+% B.Z should be (D-1)-by-1 or 1-by-(D-1)
+%
+% OUTPUT:
+% p   is N-by-1
 
 if B.Z==0  % uniform
     p = 1/B.F;
     return
 end
 
-% make x a row vector
-if size(x,1)>1
-    x = x';
-end
+% make z a column vector
+z = B.Z(:);
 
-% make z a row vector
-z = B.Z;
-if size(z,1)>1
-    z = z';
-end
-
-p = exp(sum(z.*(x*B.V).^2)) / B.F;
+p = exp((x*B.V).^2*z) / B.F;


### PR DESCRIPTION
Computation of the normalizing constant (bingham_F) was failing for d=1. To fix, I had to transpose something...
I also modified bingham_pdf to allow matrix (N-by-D) inputs for x, which speeds up the computation substantially when evaluating the likelihood of multiple samples.
