### PR TITLE
Modify Makefile so that it is compatible with GCC v5

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -8,6 +8,8 @@ INSTALL_DIR=/usr
 CC=gcc
 CPP=g++
 NVCC=nvcc
+GCCVERSION := $(shell expr `$(CC) -dumpversion | cut -f1 -d.`)
+GCC5NEWER := $(shell expr `echo $(GCCVERSION)` \>= 5)
 #MEX=mex
 LINK=ar rcs
 CFLAGS=-Wall -I$(IDIR) -O3 -msse2
@@ -21,6 +23,9 @@ CUDAFLAGS=-O3 -lcuda -lcudart -lcurand -arch=compute_20
 #CYGWIN=1
 #WINDOWS=1
 
+ifeq "$(GCC5NEWER)" "1"
+CFLAGS += -fgnu89-inline
+endif
 
 ifdef WINDOWS
 CFLAGS += -static -mno-cygwin -I"C:\Program Files\GnuWin32\include" -DHAVE_WINDOWS #-mwindows -I/usr/include


### PR DESCRIPTION
I just learned the hard way that I have gcc 5.1.1. The implication of that is that the default standard is `gnu11` instad of `gnu89`, as announced [here](https://gcc.gnu.org/gcc-5/porting_to.html)

Trying to compile the c code as it is now with the newer version of gcc fails. I understand it is an incompatibility with the inline functions.

The solution I found is to include the flag `-fgnu89-inline` as suggested [here](http://stackoverflow.com/a/13121144). Another possibility would be to directly add the flag `-std=gnu89` to keep using the old dialect. I went for the first one.

I modified the `Makefile` file to check the version of gcc and if it is larger or equal than 5, it adds the flag `-fgnu89-inline`. It is tested for `gcc 5.1.1` but not with an older version.

I don't have much experience with Makefiles so let me know if there's anything that could be done in a better way.
